### PR TITLE
解析 YAML 文件构造 Kether 对象

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ vendor/
 
 # OSX trash
 .DS_Store
+
+# Product
+main

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2022 Zhang Zhanpeng <zhangregister@outlook.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"github.com/MonteCarloClub/kether/object"
+	"github.com/spf13/cobra"
+)
+
+// deployCmd represents the deploy command
+var (
+	dryRun   bool
+	yamlPath string
+
+	deployCmd = &cobra.Command{
+		Use:   "deploy",
+		Short: "A brief description of your command",
+		Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			object.Register(dryRun, yamlPath)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	deployCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output actions to be performed without changing any state")
+	deployCmd.Flags().StringVarP(&yamlPath, "file", "f", "", "Construct Kether object and its state with this YAML file path (required)")
+	deployCmd.MarkFlagRequired("file")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/MonteCarloClub/kether
 go 1.15
 
 require (
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDN
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=

--- a/object/parse.go
+++ b/object/parse.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2022 Zhang Zhanpeng <zhangregister@outlook.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package object
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+func ParseYaml(yamlPath string) (*KetherObject, *KetherObjectState) {
+	ext := filepath.Ext(yamlPath)
+	if ext != ".yaml" && ext != ".yml" {
+		logrus.Warnf("%v may not be a legal yaml file", yamlPath)
+	}
+
+	yamlBytes, err := ioutil.ReadFile(yamlPath)
+	if err != nil {
+		logrus.Errorf("fail to read yaml file, yamlPath: %v, err: %v", yamlPath, err)
+		return nil, nil
+	}
+
+	ketherObjectEntity := &KetherObjectEntity{}
+	err = yaml.Unmarshal(yamlBytes, &ketherObjectEntity)
+	if err != nil {
+		logrus.Errorf("fail to unmarshal yaml, yamlBytes: %v, err: %v", string(yamlBytes), err)
+		return nil, nil
+	}
+
+	ketherObject := ketherObjectEntity.GetKetherObject()
+	ketherObjectState := ketherObjectEntity.GetKetherObjectState()
+	ketherObjectState.SetState(REGISTERED)
+	return ketherObject, ketherObjectState
+}

--- a/object/register.go
+++ b/object/register.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2022 Zhang Zhanpeng <zhangregister@outlook.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package object
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+func Register(dryRun bool, yamlPath string) {
+	ketherObject, ketherObjectState := ParseYaml(yamlPath)
+	if ketherObject == nil {
+		logrus.Infof("fail to get kether object from yaml file, yamlPath: %v", yamlPath)
+		return
+	}
+	if ketherObjectState == nil {
+		logrus.Infof("fail to get kether object state from yaml file, yamlPath: %v", yamlPath)
+		return
+	}
+	if dryRun {
+		logrus.Infof("registering kether object in dry run mode will not change any state")
+	}
+	// TODO 根据 ketherObject 部署服务，根据 ketherObjectState 注册服务状态
+}

--- a/object/utils.go
+++ b/object/utils.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2022 Zhang Zhanpeng <zhangregister@outlook.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package object
+
+type ResourceDescriptionEntity struct {
+	DockerImageRepository string `yaml:"repository"`
+	DockerImageTag        string `yaml:"tag"`
+}
+
+type RunDescriptionEntity struct {
+	HostPort      string `yaml:"host_port"`
+	ContainerPort string `yaml:"container_port"`
+}
+
+type KetherObjectEntity struct {
+	Name        string                    `yaml:"name"`
+	Kind        string                    `yaml:"kind"`
+	Predicate   ResourceDescriptionEntity `yaml:"predicate"`
+	Priority    ResourceDescriptionEntity `yaml:"priority"`
+	Requirement RunDescriptionEntity      `yaml:"requirement"`
+}
+
+// ResourceDescription 描述 Kether 对象的资源需求
+type ResourceDescription ResourceDescriptionEntity
+
+// RunDescription 描述运行 Kether 对象的需求，对应 `docker run` 的选项
+type RunDescription RunDescriptionEntity
+
+// KetherObject 是 Kether 对象
+type KetherObject struct {
+	Name                string
+	Predicate, Priority *ResourceDescription
+	Requirement         *RunDescription
+}
+
+// KetherObjectStateType Kether 对象状态类型
+type KetherObjectStateType int8
+
+const (
+	UNREGISTERED KetherObjectStateType = 0
+	REGISTERED   KetherObjectStateType = 1
+	// TODO 新增后缀状态，包含状态转换中、成功和失败，建议成功和失败的状态值互为相反数
+)
+
+// KetherObjectState 是 Kether 对象状态
+type KetherObjectState struct {
+	Name  string
+	State KetherObjectStateType
+}
+
+func (ketherObjectEntity *KetherObjectEntity) GetKetherObject() *KetherObject {
+	return &KetherObject{
+		Name: ketherObjectEntity.Name,
+		Predicate: &ResourceDescription{
+			DockerImageRepository: ketherObjectEntity.Predicate.DockerImageRepository,
+			DockerImageTag:        ketherObjectEntity.Predicate.DockerImageTag,
+		},
+		Priority: &ResourceDescription{
+			DockerImageRepository: ketherObjectEntity.Priority.DockerImageRepository,
+			DockerImageTag:        ketherObjectEntity.Priority.DockerImageTag,
+		},
+		Requirement: &RunDescription{
+			HostPort:      ketherObjectEntity.Requirement.HostPort,
+			ContainerPort: ketherObjectEntity.Requirement.ContainerPort,
+		},
+	}
+}
+
+func (ketherObjectEntity *KetherObjectEntity) GetKetherObjectState() *KetherObjectState {
+	return &KetherObjectState{
+		Name: ketherObjectEntity.Name,
+	}
+}
+
+func (ketherObjectState *KetherObjectState) SetState(state KetherObjectStateType) {
+	ketherObjectState.State = state
+}

--- a/script/copyright_symbol_replacer.py
+++ b/script/copyright_symbol_replacer.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2022 Zhang Zhanpeng <zhangregister@outlook.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+
+
+def replace_copyright_symbol_in_file(file):
+    with open(file, 'r') as f:
+        filestr = f.read()
+        filestr = filestr.replace('©', '(c)')
+    with open(file, 'w') as f:
+        f.write(filestr)
+
+
+def replace_copyright_symbol(dirpath):
+    files = os.listdir(dirpath)
+    for file in files:
+        filepath = os.path.join(dirpath, file)
+        if os.path.isdir(filepath):
+            if filepath != '../.git' and filepath != '../vendor':
+                replace_copyright_symbol(filepath)
+        else:
+            if os.path.splitext(filepath)[-1] == '.go':
+                replace_copyright_symbol_in_file(filepath)
+
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+replace_copyright_symbol('..')

--- a/test/dao_2048.yml
+++ b/test/dao_2048.yml
@@ -1,0 +1,9 @@
+name: dao-2048-test
+kind: deploy
+predicate:
+  repository: ghcr.io/daocloud/dao-2048
+priority:
+  tag: 1.1.0-alpha.6
+requirement:
+  host_port: 8080
+  container_port: 80


### PR DESCRIPTION
实现了通过参数传递 YAML 文件，解析、构造 Kether 对象。
```bash
$ go build main.go
$ ./main deploy test/dao_2048.yml --dry-run
```

实现了脚本，把“©”全部替换为“(c)”
```bash
$ script/copyright_symbol_replacer.py
```