### PR TITLE
实现全局 Logger

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -22,8 +22,8 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"github.com/MonteCarloClub/kether/log"
 	"github.com/MonteCarloClub/kether/object"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -45,17 +45,17 @@ to quickly create a Cobra application.`,
 			// TODO 在 ctx 透传 dryRun
 			ketherObject, ketherObjectState, err := object.Register(dryRun, yamlPath)
 			if err != nil {
-				logrus.Errorf("fail to register kether object, err: %v", err)
+				log.Error("fail to register kether object", "err", err)
 				return
 			}
-			logrus.Infof("kether object registered")
+			log.Info("kether object registered")
 
 			err = object.Deploy(ketherObject, ketherObjectState)
 			if err != nil {
-				logrus.Errorf("fail to deploy ketherObject, err: %v", err)
+				log.Error("fail to deploy ketherObject", "err", err)
 				return
 			}
-			logrus.Infof("kether object deployed")
+			log.Info("kether object deployed")
 		},
 	}
 )

--- a/init.go
+++ b/init.go
@@ -19,24 +19,21 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package container
+package main
 
 import (
+	"github.com/MonteCarloClub/kether/container"
 	"github.com/MonteCarloClub/kether/log"
-	"github.com/docker/docker/client"
 )
 
-var (
-	DockerApiClient *client.Client
-)
+func init() {
+	log.InitLogger()
+	log.Info("logger inited")
 
-func InitDockerApiClient() error {
-	var err error
-	DockerApiClient, err = client.NewClientWithOpts()
+	err := container.InitDockerApiClient()
 	if err != nil {
 		log.Error("fail to init docker api client", "err", err)
-		return err
+		return
 	}
 	log.Info("docker api client inited")
-	return nil
 }

--- a/machine/port.go
+++ b/machine/port.go
@@ -22,12 +22,12 @@ THE SOFTWARE.
 package machine
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/MonteCarloClub/kether/log"
 )
 
 func CheckIfHostPortAvailable(hostPort string) bool {
 	if hostPort == "" {
-		logrus.Warnf("empty host port")
+		log.Warn("empty host port")
 		return false
 	}
 	// TODO 返回这个主机端口是否被占用

--- a/main.go
+++ b/main.go
@@ -21,7 +21,9 @@ THE SOFTWARE.
 */
 package main
 
-import "github.com/MonteCarloClub/kether/cmd"
+import (
+	"github.com/MonteCarloClub/kether/cmd"
+)
 
 func main() {
 	cmd.Execute()

--- a/object/parse.go
+++ b/object/parse.go
@@ -25,26 +25,26 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
+	"github.com/MonteCarloClub/kether/log"
 	"gopkg.in/yaml.v2"
 )
 
 func ParseYaml(yamlPath string) (*KetherObject, *KetherObjectState, error) {
 	ext := filepath.Ext(yamlPath)
 	if ext != ".yaml" && ext != ".yml" {
-		logrus.Warnf("%v may not be a legal yaml file", yamlPath)
+		log.Warn("illegal yaml file extension", "yamlPath", yamlPath)
 	}
 
 	yamlBytes, err := ioutil.ReadFile(yamlPath)
 	if err != nil {
-		logrus.Errorf("fail to read yaml file, yamlPath: %v, err: %v", yamlPath, err)
+		log.Error("fail to read yaml file", "yamlPath", yamlPath, "err", err)
 		return nil, nil, err
 	}
 
 	ketherObjectEntity := &KetherObjectEntity{}
 	err = yaml.Unmarshal(yamlBytes, &ketherObjectEntity)
 	if err != nil {
-		logrus.Errorf("fail to unmarshal yaml, yamlBytes: %v, err: %v", string(yamlBytes), err)
+		log.Error("fail to unmarshal yaml", yamlBytes, string(yamlBytes), "err", err)
 		return nil, nil, err
 	}
 

--- a/object/register.go
+++ b/object/register.go
@@ -24,25 +24,23 @@ package object
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
+	"github.com/MonteCarloClub/kether/log"
 )
 
 func Register(dryRun bool, yamlPath string) (*KetherObject, *KetherObjectState, error) {
 	var err error
 	ketherObject, ketherObjectState, err := ParseYaml(yamlPath)
 	if ketherObject == nil {
-		logrus.Errorf("fail to get kether object from yaml file, yamlPath: %v", yamlPath)
+		log.Error("fail to get kether object from yaml file", "yamlPath", yamlPath)
 		err = fmt.Errorf("empty ketherObject")
-	}
-	if ketherObjectState == nil {
-		logrus.Errorf("fail to get kether object state from yaml file, yamlPath: %v", yamlPath)
+	} else if ketherObjectState == nil {
+		log.Error("fail to get kether object state from yaml file", "yamlPath", yamlPath)
 		err = fmt.Errorf("empty ketherObjectState")
-	}
-	if err != nil {
-		logrus.Errorf("fail to parse yaml file, err: %v", err)
+	} else if err != nil {
+		log.Error("fail to parse yaml file", "err", err)
 	}
 	if dryRun {
-		logrus.Infof("registering kether object in dry run mode will not change any state")
+		log.Info("registering kether object in dry run mode will not change any state")
 	}
 	// TODO 根据 ketherObject 部署服务，根据 ketherObjectState 注册服务状态
 	return ketherObject, ketherObjectState, err

--- a/object/utils.go
+++ b/object/utils.go
@@ -24,10 +24,10 @@ package object
 import (
 	"fmt"
 
+	"github.com/MonteCarloClub/kether/log"
 	"github.com/MonteCarloClub/kether/machine"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
-	"github.com/sirupsen/logrus"
 )
 
 type ResourceDescriptionEntity struct {
@@ -110,18 +110,26 @@ func (ketherObject *KetherObject) GetImageName() string {
 	if tag == "" {
 		tag = ketherObject.Priority.DockerImageTag
 	}
+
+	if repository == "" {
+		log.Error("empty image name", "err", fmt.Errorf("empty repository"))
+		return ""
+	}
+	if tag == "" {
+		return repository
+	}
 	return fmt.Sprintf("%v:%v", repository, tag)
 }
 
 func (ketherObject *KetherObject) GetContainerConfig() (*container.Config, *container.HostConfig) {
 	hostPort, containerPort := ketherObject.Requirement.HostPort, ketherObject.Requirement.ContainerPort
 	if containerPort == "" {
-		logrus.Infof("no exposed port")
+		log.Info("no exposed port")
 		return nil, nil
 	}
 	if !machine.CheckIfHostPortAvailable(hostPort) {
 		hostPort = machine.GetAvailableHostPort()
-		logrus.Infof("no available host port specified, mapped to %v", hostPort)
+		log.Info("no available host port specified", "mapped host port", hostPort)
 	}
 
 	containerConfig := &container.Config{


### PR DESCRIPTION
打印日志为 JSON 格式，例如运行下列命令：
```bash
$ go build main.go init.go
$ ./main deploy -f test/dao_2048.yml
$ docker stop {CONTAINER ID}
```
日志如下：
```
{"level":"info","msg":"logger inited","time":"2022-02-15 01:17:01.994"}
{"level":"info","msg":"logger inited","time":"2022-02-15 01:17:01.994"}
{"level":"info","msg":"docker api client inited","time":"2022-02-15 01:17:01.995"}
{"level":"info","msg":"docker api client inited","time":"2022-02-15 01:17:01.995"}
{"level":"info","msg":"kether object registered","time":"2022-02-15 01:17:01.995"}
{"level":"info","msg":"docker image pulled","refStr":"ghcr.io/daocloud/dao-2048:1.1.0-alpha.6","time":"2022-02-15 01:17:18.843"}
{"level":"info","msg":"docker image pulled","time":"2022-02-15 01:17:18.843"}
{"id":"cbc0af46d7f20e2ba2ba7af33f94966648cdcbce2529935c15149fd72b31814a","level":"info","msg":"container created","time":"2022-02-15 01:17:18.889"}
{"level":"info","msg":"container created","time":"2022-02-15 01:17:18.889"}
{"id":"cbc0af46d7f20e2ba2ba7af33f94966648cdcbce2529935c15149fd72b31814a","level":"info","msg":"container started","time":"2022-02-15 01:17:19.052"}
{"id":"cbc0af46d7f20e2ba2ba7af33f94966648cdcbce2529935c15149fd72b31814a","level":"info","msg":"container not running","time":"2022-02-15 01:19:49.982"}
{"level":"info","msg":"container run","time":"2022-02-15 01:19:49.982"}
{"level":"info","msg":"kether object deployed","time":"2022-02-15 01:19:49.982"}
```