### PR TITLE
在上下文传递 `dry-run` 并在 `deploy` 支持它

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -22,6 +22,9 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"context"
+
+	"github.com/MonteCarloClub/kether/flag"
 	"github.com/MonteCarloClub/kether/log"
 	"github.com/MonteCarloClub/kether/object"
 	"github.com/spf13/cobra"
@@ -42,15 +45,17 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// TODO 在 ctx 透传 dryRun
-			ketherObject, ketherObjectState, err := object.Register(dryRun, yamlPath)
+			ctx := context.WithValue(context.Background(), flag.ContextKey, flag.ContextValType{
+				DryRun: dryRun,
+			})
+			ketherObject, ketherObjectState, err := object.Register(ctx, yamlPath)
 			if err != nil {
 				log.Error("fail to register kether object", "err", err)
 				return
 			}
 			log.Info("kether object registered")
 
-			err = object.Deploy(ketherObject, ketherObjectState)
+			err = object.Deploy(ctx, ketherObject, ketherObjectState)
 			if err != nil {
 				log.Error("fail to deploy ketherObject", "err", err)
 				return

--- a/container/container.go
+++ b/container/container.go
@@ -50,13 +50,15 @@ func RunDockerContainer(ctx context.Context, id string) error {
 	}
 	log.Info("container started", "id", id)
 
-	containerWaitOKBodyChan, errChan := DockerApiClient.ContainerWait(ctx, id, container.WaitConditionNotRunning)
+	statusCh, errChan := DockerApiClient.ContainerWait(ctx, id, container.WaitConditionNotRunning)
 	select {
-	case <-containerWaitOKBodyChan:
+	case <-statusCh:
 		log.Info("container not running", "id", id)
 	case err := <-errChan:
 		log.Error("error encountered while container running", "id", id, "err", err)
 		return err
 	}
+
+	// TODO 输出容器日志，参考：https://docs.docker.com/engine/api/sdk/examples/
 	return nil
 }

--- a/flag/context.go
+++ b/flag/context.go
@@ -19,40 +19,14 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package container
+package flag
 
-import (
-	"context"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
+type ContextKeyType string
 
-	"github.com/MonteCarloClub/kether/log"
-	"github.com/docker/docker/api/types"
-)
-
-func PullDockerImage(ctx context.Context, imageName string) error {
-	var err error
-	if imageName == "" {
-		err = fmt.Errorf("empty image name")
-		log.Error("empty image name", "err", err)
-		return err
-	}
-
-	reader, err := DockerApiClient.ImagePull(ctx, imageName, types.ImagePullOptions{})
-	var dst io.Writer
-	if log.IfTraceOrDebug() {
-		dst = os.Stdout
-	} else {
-		dst = ioutil.Discard
-	}
-	defer reader.Close()
-	io.Copy(dst, reader)
-	if err != nil {
-		log.Error("fail to pull docker image", "refStr", imageName, "err", err)
-		return err
-	}
-	log.Info("docker image pulled", "refStr", imageName)
-	return nil
+type ContextValType struct {
+	DryRun bool
 }
+
+const (
+	ContextKey ContextKeyType = "CTXKEY"
+)

--- a/object/register.go
+++ b/object/register.go
@@ -22,12 +22,14 @@ THE SOFTWARE.
 package object
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/MonteCarloClub/kether/flag"
 	"github.com/MonteCarloClub/kether/log"
 )
 
-func Register(dryRun bool, yamlPath string) (*KetherObject, *KetherObjectState, error) {
+func Register(ctx context.Context, yamlPath string) (*KetherObject, *KetherObjectState, error) {
 	var err error
 	ketherObject, ketherObjectState, err := ParseYaml(yamlPath)
 	if ketherObject == nil {
@@ -39,9 +41,8 @@ func Register(dryRun bool, yamlPath string) (*KetherObject, *KetherObjectState, 
 	} else if err != nil {
 		log.Error("fail to parse yaml file", "err", err)
 	}
-	if dryRun {
+	if ctx.Value(flag.ContextKey).(flag.ContextValType).DryRun {
 		log.Info("registering kether object in dry run mode will not change any state")
 	}
-	// TODO 根据 ketherObject 部署服务，根据 ketherObjectState 注册服务状态
 	return ketherObject, ketherObjectState, err
 }

--- a/object/utils.go
+++ b/object/utils.go
@@ -151,5 +151,6 @@ func (ketherObject *KetherObject) GetContainerConfig() (*container.Config, *cont
 }
 
 func (ketherObjectState *KetherObjectState) SetState(state KetherObjectStateType) {
+	// TODO 根据 ketherObjectState 注册服务状态
 	ketherObjectState.State = state
 }


### PR DESCRIPTION
运行下列命令：
```bash
$ go build main.go init.go
$ ./main deploy -f test/dao_2048.yml --dry-run
```
日志如下：
```
{"level":"info","msg":"logger inited","time":"2022-02-16 00:32:43.419"}
{"level":"info","msg":"logger inited","time":"2022-02-16 00:32:43.420"}
{"level":"info","msg":"docker api client inited","time":"2022-02-16 00:32:43.420"}
{"level":"info","msg":"docker api client inited","time":"2022-02-16 00:32:43.420"}
{"level":"info","msg":"registering kether object in dry run mode will not change any state","time":"2022-02-16 00:32:43.420"}
{"level":"info","msg":"kether object registered","time":"2022-02-16 00:32:43.420"}
{"imageName":"ghcr.io/daocloud/dao-2048:1.1.0-alpha.6","level":"info","msg":"image name gotten","time":"2022-02-16 00:32:43.420"}
{"containerConfig":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"ExposedPorts":{"80":{}},"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":null,"Image":"ghcr.io/daocloud/dao-2048:1.1.0-alpha.6","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"level":"info","msg":"container config gotten","time":"2022-02-16 00:32:43.420"}
{"hostConfig":{"Binds":null,"ContainerIDFile":"","LogConfig":{"Type":"","Config":null},"NetworkMode":"","PortBindings":{"80":[{"HostIp":"","HostPort":"8080"}]},"RestartPolicy":{"Name":"","MaximumRetryCount":0},"AutoRemove":false,"VolumeDriver":"","VolumesFrom":null,"CapAdd":null,"CapDrop":null,"CgroupnsMode":"","Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"GroupAdd":null,"IpcMode":"","Cgroup":"","Links":null,"OomScoreAdj":0,"PidMode":"","Privileged":false,"PublishAllPorts":false,"ReadonlyRootfs":false,"SecurityOpt":null,"UTSMode":"","UsernsMode":"","ShmSize":0,"ConsoleSize":[0,0],"Isolation":"","CpuShares":0,"Memory":0,"NanoCpus":0,"CgroupParent":"","BlkioWeight":0,"BlkioWeightDevice":null,"BlkioDeviceReadBps":null,"BlkioDeviceWriteBps":null,"BlkioDeviceReadIOps":null,"BlkioDeviceWriteIOps":null,"CpuPeriod":0,"CpuQuota":0,"CpuRealtimePeriod":0,"CpuRealtimeRuntime":0,"CpusetCpus":"","CpusetMems":"","Devices":null,"DeviceCgroupRules":null,"DeviceRequests":null,"KernelMemory":0,"KernelMemoryTCP":0,"MemoryReservation":0,"MemorySwap":0,"MemorySwappiness":null,"OomKillDisable":null,"PidsLimit":null,"Ulimits":null,"CpuCount":0,"CpuPercent":0,"IOMaximumIOps":0,"IOMaximumBandwidth":0,"MaskedPaths":null,"ReadonlyPaths":null},"level":"info","msg":"host config gotten","time":"2022-02-16 00:32:43.420"}
{"level":"info","msg":"deploying kether object in dry run mode will not change any state","time":"2022-02-16 00:32:43.421"}
{"level":"info","msg":"kether object deployed","time":"2022-02-16 00:32:43.421"}
```