### PR TITLE
根据 `predicate` 和 `priority` 选择最优镜像，轮询主机端口选择可用的

### DIFF
--- a/container/image.go
+++ b/container/image.go
@@ -32,6 +32,11 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+func CheckIfDockerImageAvailable(imageName string) bool {
+	// TODO 根据 Docker 镜像名检查对应的 Docker 镜像是否可用
+	return true
+}
+
 func PullDockerImage(ctx context.Context, imageName string) error {
 	var err error
 	if imageName == "" {

--- a/machine/port.go
+++ b/machine/port.go
@@ -23,7 +23,6 @@ package machine
 
 import (
 	"fmt"
-	"math/rand"
 	"net"
 	"strconv"
 
@@ -45,9 +44,9 @@ func CheckIfHostPortAvailable(hostPort string) bool {
 
 func GetAvailableHostPort() string {
 	for i := 0; i < 1000; i++ {
-		randHostPort := strconv.Itoa(8000 + rand.Intn(1000))
-		if CheckIfHostPortAvailable(randHostPort) {
-			return randHostPort
+		candidateHostPort := strconv.Itoa(8000 + i)
+		if CheckIfHostPortAvailable(candidateHostPort) {
+			return candidateHostPort
 		}
 	}
 	log.Warn("fail to get available host port in [8000, 9000)")


### PR DESCRIPTION
- 此前，在 `GetImageName` 实际并未根据 `predicate` 和 `priority` 选择最优镜像。
- 在 `GetAvailableHostPort`，轮询主机端口 [8000, 9000)，选择一个可用的。