### PR TITLE
支持后台运行 Docker 容器

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -62,3 +62,13 @@ func RunDockerContainer(ctx context.Context, id string) error {
 	// TODO 输出容器日志，参考：https://docs.docker.com/engine/api/sdk/examples/
 	return nil
 }
+
+func RunDockerContainerInBackground(ctx context.Context, id string) error {
+	err := DockerApiClient.ContainerStart(ctx, id, types.ContainerStartOptions{})
+	if err != nil {
+		log.Error("fail to start container in background", "id", id, "err", err)
+		return err
+	}
+	log.Info("container started in background", "id", id)
+	return nil
+}

--- a/object/deploy.go
+++ b/object/deploy.go
@@ -69,13 +69,17 @@ func Deploy(ctx context.Context, ketherObject *KetherObject, ketherObjectState *
 	}
 	log.Info("container created")
 
-	err = container.RunDockerContainer(ctx, id)
+	if ketherObject.Requirement.Detach {
+		err = container.RunDockerContainerInBackground(ctx, id)
+	} else {
+		err = container.RunDockerContainer(ctx, id)
+	}
 	if err != nil {
 		ketherObjectState.SetState(FAIL_TO_DEPLOY)
-		log.Error("fail to run docker container", "err", err)
+		log.Error("fail to run docker container in {foreground|background}", "err", err)
 		return err
 	}
 	ketherObjectState.SetState(DEPLOYED)
-	log.Info("container run")
+	log.Info("container run in {foreground|background}")
 	return nil
 }

--- a/object/utils.go
+++ b/object/utils.go
@@ -38,6 +38,7 @@ type ResourceDescriptionEntity struct {
 }
 
 type RunDescriptionEntity struct {
+	Detach      bool     `yaml:"detach"`
 	PublishList []string `yaml:"publish_list"`
 }
 
@@ -91,6 +92,7 @@ func (ketherObjectEntity *KetherObjectEntity) GetKetherObject() *KetherObject {
 			DockerImageTag:        ketherObjectEntity.Priority.DockerImageTag,
 		},
 		Requirement: &RunDescription{
+			Detach:      ketherObjectEntity.Requirement.Detach,
 			PublishList: ketherObjectEntity.Requirement.PublishList,
 		},
 	}

--- a/test/http_https_echo.yml
+++ b/test/http_https_echo.yml
@@ -5,6 +5,7 @@ predicate:
 priority:
   tag: 23
 requirement:
+  detach: true
   publish_list:
     - 8080:8080
     - 8443:8443


### PR DESCRIPTION
缺省地，`kether` 启动的 Docker 容器在前台运行，可以在 YAML 显式地要求 Docker 容器在后台运行，通过在 `requirement` 字段声明 `detach: true` 实现。
对在后台运行的 Docker 容器，`kether` 将不等待容器进程退出。